### PR TITLE
Fixed build error on macOS11

### DIFF
--- a/google-diff-match-patch-Objective-C/NSString+UriCompatibility.m
+++ b/google-diff-match-patch-Objective-C/NSString+UriCompatibility.m
@@ -30,17 +30,11 @@
  * Escape excluding selected chars for compatability with JavaScript's encodeURI.
  * This method produces uppercase hex.
  *
- * @param str The CFStringRef to escape.
- * @return The escaped CFStringRef.
+ * @return The escaped NSString.
  */
 - (NSString *)diff_stringByAddingPercentEscapesForEncodeUriCompatibility;
 {
-  CFStringRef urlString = CFURLCreateStringByAddingPercentEscapes(NULL,
-                                  JX_BRIDGED_CAST(CFStringRef, self),
-                                  CFSTR(" !~*'();/?:@&=+$,#"),
-                                  NULL,
-                                  kCFStringEncodingUTF8);
-  return JX_TRANSFER_CF_TO_OBJC(NSString *, urlString);
+  return [self stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet characterSetWithCharactersInString:@" !~*'();/?:@&=+$,#"]];
 }
 
 /**
@@ -52,11 +46,7 @@
  */
 - (NSString *)diff_stringByReplacingPercentEscapesForEncodeUriCompatibility;
 {
-  CFStringRef decodedString = CFURLCreateStringByReplacingPercentEscapesUsingEncoding(NULL, 
-                                            JX_BRIDGED_CAST(CFStringRef, self), 
-                                            CFSTR(""), 
-                                            kCFStringEncodingUTF8);
-  return JX_TRANSFER_CF_TO_OBJC(NSString *, decodedString);
+  return [self stringByRemovingPercentEncoding];
 }
 
 @end


### PR DESCRIPTION
'CFURLCreateStringByAddingPercentEscapes' is deprecated: first deprecated in macOS 10.11 - Use [NSString stringByAddingPercentEncodingWithAllowedCharacters:] instead, which always uses the recommended UTF-8 encoding, and which encodes for a specific URL component or subcomponent (since each URL component or subcomponent has different rules for what characters are valid).